### PR TITLE
Add runtime UI and fix misc issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ git clone https://github.com/ulsc/brown-noise.git
 cd brown-noise
 ```
 
-4. Build the Go application:
+3. Build the Go application:
 
 ```bash
 go build -o brown_noise main.go

--- a/toggle_noise.sh
+++ b/toggle_noise.sh
@@ -1,11 +1,11 @@
 #!/bin/zsh
 
 # Check if the brown_noise process is running
-pid=$(pgrep -f "brown_noise")
+pid=$(pgrep -f "./brown_noise")
 
 if [ -z "$pid" ]; then
   # If the process is not running, start it
-  nohup brown_noise > /dev/null 2>&1 &
+  nohup ./brown_noise > /dev/null 2>&1 &
   echo "Brown noise started."
 else
   # If the process is running, kill it


### PR DESCRIPTION
## Summary
- fix installation step numbering in README
- execute brown_noise using local path in toggle script
- fix grammar and close CPU profile handle in tests
- serve a basic web UI at `:8080` to tweak alpha, pitch and volume

## Testing
- `go test ./...` *(fails: package `alsa` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fdbe8c1b0832791d36227faa13455